### PR TITLE
fix Function.caller Error in Safari

### DIFF
--- a/js/plugins.js
+++ b/js/plugins.js
@@ -1,6 +1,13 @@
-// usage: log('inside coolFunc', this, arguments);
-// paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
-window.log = function f(){ log.history = log.history || []; log.history.push(arguments); if(this.console) { var args = arguments, newarr; args.callee = args.callee.caller; newarr = [].slice.call(args); if (typeof console.log === 'object') log.apply.call(console.log, console, newarr); else console.log.apply(console, newarr);}};
+// usage: log('inside coolFunc',this,arguments);
+// http://paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/
+window.log = function(){
+  log.history = log.history || [];   // store logs to an array for reference
+  log.history.push(arguments);
+  if(this.console){
+    console.log( Array.prototype.slice.call(arguments) );
+  }
+};
+
 
 // make it safe to use console.log always
 (function(a){function b(){}for(var c="assert,count,debug,dir,dirxml,error,exception,group,groupCollapsed,groupEnd,info,log,markTimeline,profile,profileEnd,time,timeEnd,trace,warn".split(","),d;!!(d=c.pop());){a[d]=a[d]||b;}})


### PR DESCRIPTION
This updates Paul Irish's log wrapper to his [most recently published version](http://www.paulirish.com/2009/log-a-lightweight-wrapper-for-consolelog/),
which is simpler than what was here before and doesn't use 'caller' or 'callee'.
These are deprecated and Safari now fails when these are called on a strict mode function,
such as those in easy-xdm.js.

I'm also using the non-minified version, because it's easier to understand.

This is the same change as CruGlobal/paycheck-history#12, though it's not causing problems as much because it's not common for `log()` to get called here. In paycheck-history, `log()` gets called whenever someone doesn't have a spouse (the `/authentication//my/spouse/employeeId` call returns a 404). MPGA doesn't need to call that endpoint.
But it's possible that `log()` can get called if there's an error of some kind, and we definitely don't want Safari or other browsers bombing out in this case.